### PR TITLE
Add metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ This package is written in TypeScript, but can be included in any javascript pro
 
 * `PaintedEvent` - TypeScript type for the `Painted` log event data
 
+* `Metadata` - TypeScript type for the token metadata
+
 * `extract(event: LogEvent): PaintedEvent` -  Extracts encoded pixel data from the smart contract log event
 
 * `process(event: PaintedEvent)` - Decodes the extracted data into pixel data, consisting of the pixel coordinate and color, that can be drawn onto a [HTML Canvas](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API)
+
+* `parseMetadata(event: PaintedEvent)` - Parses the metadata in the `PaintedEvent` to return the `name`, `number`, `seriesId` and `hasAlpha` properties. Raw metadata is just a string array
 
 
 ## Feedback

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { extract, process, PaintedEvent, Pixels } from './events/event'
+import { parse as parseMetadata, Metadata } from './metadata'
 
-export { extract, process, PaintedEvent, Pixels }
+export { extract, process, parseMetadata, PaintedEvent, Pixels, Metadata }

--- a/src/metadata/index.ts
+++ b/src/metadata/index.ts
@@ -1,0 +1,40 @@
+import { hexToAscii, numberToHex, padLeft } from 'web3-utils'
+import { PaintedEvent } from '../events/event'
+
+export type Metadata = OtherMetadata & {
+  name: Name
+}
+
+type Name = string
+
+type OtherMetadata = {
+  number: number
+  seriesId: number
+  hasAlpha: boolean
+}
+
+const parseName = (raw: string): Name => hexToAscii(numberToHex(raw)).replace(/[\u0000-\u001F]/g, '').trim()
+
+/**
+ * First 3 bytes are the number
+ * Next 3 bytes are the seriesId
+ * Last bit is the alpha channel flag
+ * 
+ * @param raw 
+ */
+const parseOtherMetadata = (raw: string): OtherMetadata => {
+  const asHex = padLeft(numberToHex(raw), 64).slice(2)
+  const number = parseInt(`0x${asHex.slice(0, 6)}`)
+  const seriesId = parseInt(`0x${asHex.slice(6, 12)}`)
+  const hasAlpha = asHex.slice(asHex.length - 1) !== '0'
+  return { number, seriesId, hasAlpha }
+}
+
+export const parse = (event: PaintedEvent): Metadata => {
+  const rawMetadata = event.metadata || []
+  const [rawName, rawOther] = rawMetadata
+  return {
+    name: parseName(rawName),
+    ...parseOtherMetadata(rawOther)
+  }
+}


### PR DESCRIPTION
Adds function to parse event metadata, which is a string array in its raw form.

Takes `PaintedEvent` as input and returns parsed metadata:
```
{
  name: string
  number: number
  seriesId: number
  hasAlpha: boolean
}
```